### PR TITLE
s3: obey the borrow checker

### DIFF
--- a/src/objects/s3.rs
+++ b/src/objects/s3.rs
@@ -41,14 +41,14 @@ impl S3Config {
             .build();
 
         Ok(S3 {
-            config: self,
+            bucket_name: self.bucket_name.clone(),
             client: Client::from_conf(config),
         })
     }
 }
 
 pub struct S3 {
-    config: *S3Config,
+    bucket_name: String,
     client: Client,
 }
 
@@ -59,7 +59,7 @@ impl S3 {
             .put_object()
             .key(digest)
             .body(body.into())
-            .bucket(self.config.bucket_name.as_str())
+            .bucket(&self.bucket_name)
             .send()
             .await?;
         Ok(())


### PR DESCRIPTION
In #2, `S3Config` was added to the `S3` object which isn't strictly necessary and leads to compiler errors since the `S3Config` would subsequently be owned by both the top-level portfolio config AND the `S3` object. (Rust prohibits multiple ownership of the same data, though it does allow various types of reference to the same data)

This PR just clones the bucket name into the `S3` object. In the future we will have to implement some kind of `S3Factory` to generate `S3` instances based on S3 credentials retrieved through a `WWW-Authenticate` authentication workflow.