### PR TITLE
http/blobs: finish POST-PATCH-PUT chunked upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,6 +2276,9 @@ name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tower = "0.4"
 sqlx = { version = "0.5", features = [ "runtime-tokio-native-tls", "postgres", "migrate", "json", "chrono", "uuid" ] }
 #sqlx = { path = "../sqlx", features = [ "runtime-tokio-native-tls", "postgres", "migrate" ] }
 chrono = "~0.4"
-uuid = "~0.8"
+uuid = { version = "~0.8", features = [ "v4" ] }
 
 http = "0.2"
 http-body = "0.4"

--- a/db/postgres/migrations/20220429032431_add-object-key-to-blobs-table.down.sql
+++ b/db/postgres/migrations/20220429032431_add-object-key-to-blobs-table.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE blobs
+DROP COLUMN object_key;

--- a/db/postgres/migrations/20220429032431_add-object-key-to-blobs-table.up.sql
+++ b/db/postgres/migrations/20220429032431_add-object-key-to-blobs-table.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE blobs
+ADD COLUMN object_key UUID NOT NULL;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,5 @@
+use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::http::{StatusCode};
 use thiserror;
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -22,11 +22,15 @@ pub enum Error {
     #[error("aws sdk put object error")]
     AWSSDKPutObjectError(#[from] aws_sdk_s3::types::SdkError<aws_sdk_s3::error::PutObjectError>),
     #[error("aws sdk create multipart upload error")]
-    AWSSDKCreateMultiPartUploadError(#[from] aws_sdk_s3::types::SdkError<aws_sdk_s3::error::CreateMultipartUploadError>),
+    AWSSDKCreateMultiPartUploadError(
+        #[from] aws_sdk_s3::types::SdkError<aws_sdk_s3::error::CreateMultipartUploadError>,
+    ),
     #[error("aws sdk upload part error")]
     AWSSDKUploadPartError(#[from] aws_sdk_s3::types::SdkError<aws_sdk_s3::error::UploadPartError>),
     #[error("aws sdk complete multipart upload error")]
-    AWSSDKCompleteMultipartUploadError(#[from] aws_sdk_s3::types::SdkError<aws_sdk_s3::error::CompleteMultipartUploadError>),
+    AWSSDKCompleteMultipartUploadError(
+        #[from] aws_sdk_s3::types::SdkError<aws_sdk_s3::error::CompleteMultipartUploadError>,
+    ),
 
     #[error("failed to initiate chunked upload: {0}")]
     ObjectsFailedToInitiateChunkedUpload(&'static str),
@@ -57,27 +61,39 @@ pub enum Error {
 
 #[derive(Debug)]
 pub enum DistributionErrorCode {
-    BlobUnknown = 1, // blob unknown to registry
-    BlobUploadInvalid = 2, // blob upload invalid
-    BlobUploadUnknown = 3, // blob upload unknown to registry
-    DigestInvalid = 4, // provided digest did not match uploaded content
+    BlobUnknown = 1,         // blob unknown to registry
+    BlobUploadInvalid = 2,   // blob upload invalid
+    BlobUploadUnknown = 3,   // blob upload unknown to registry
+    DigestInvalid = 4,       // provided digest did not match uploaded content
     ManifestBlobUnknown = 5, // manifest references a manifest or blob unknown to registry
-    ManifestInvalid = 6, // manifest invalid
-    ManifestUnknown = 7, // manifest unknown to registry
-    NameInvalid = 8, // invalid repository name
-    NameUnknown = 9, // repository name not known to registry
-    SizeInvalid = 10, // provided length did not match content length
-    Unauthorized = 12, // authentication required
-    Denied = 13, // request access to the resource is denied
-    Unsupported = 14, // the operation is unsupported
-    TooManyRequests = 15, // too many requests
+    ManifestInvalid = 6,     // manifest invalid
+    ManifestUnknown = 7,     // manifest unknown to registry
+    NameInvalid = 8,         // invalid repository name
+    NameUnknown = 9,         // repository name not known to registry
+    SizeInvalid = 10,        // provided length did not match content length
+    Unauthorized = 12,       // authentication required
+    Denied = 13,             // request access to the resource is denied
+    Unsupported = 14,        // the operation is unsupported
+    TooManyRequests = 15,    // too many requests
 }
 
 impl DistributionErrorCode {
     fn status_code(&self) -> StatusCode {
         match self {
-            DistributionErrorCode::BlobUploadUnknown => StatusCode::BAD_REQUEST,
+            DistributionErrorCode::BlobUnknown => StatusCode::NOT_FOUND,
             DistributionErrorCode::BlobUploadInvalid => StatusCode::RANGE_NOT_SATISFIABLE,
+            DistributionErrorCode::BlobUploadUnknown => StatusCode::BAD_REQUEST,
+            DistributionErrorCode::DigestInvalid => StatusCode::BAD_REQUEST,
+            DistributionErrorCode::ManifestBlobUnknown => StatusCode::NOT_FOUND,
+            DistributionErrorCode::ManifestInvalid => StatusCode::BAD_REQUEST,
+            DistributionErrorCode::ManifestUnknown => StatusCode::BAD_REQUEST,
+            DistributionErrorCode::NameInvalid => StatusCode::BAD_REQUEST,
+            DistributionErrorCode::NameUnknown => StatusCode::NOT_FOUND,
+            DistributionErrorCode::SizeInvalid => StatusCode::BAD_REQUEST,
+            DistributionErrorCode::Unauthorized => StatusCode::UNAUTHORIZED,
+            DistributionErrorCode::Denied => StatusCode::FORBIDDEN,
+            DistributionErrorCode::Unsupported => StatusCode::NOT_IMPLEMENTED,
+            DistributionErrorCode::TooManyRequests => StatusCode::TOO_MANY_REQUESTS,
         }
     }
 }
@@ -85,27 +101,17 @@ impl DistributionErrorCode {
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
         match self {
-            Error::DistributionSpecError(dec) => {
-                (dec.status_code(), format!("{:?}", dec))
-            },
-            Error::InvalidUuid(_) => {
-                (StatusCode::BAD_REQUEST, format!("{}", self))
-            },
-            Error::InvalidDigest(_) => {
-                (StatusCode::BAD_REQUEST, format!("{}", self))
-            },
-            Error::MissingHeader(_) => {
-                (StatusCode::BAD_REQUEST, format!("{}", self))
-            },
-            Error::InvalidHeaderValue(_) => {
-                (StatusCode::BAD_REQUEST, format!("{}", self))
-            },
-            Error::MissingPathParameter(_) => {
-                (StatusCode::BAD_REQUEST, format!("{}", self))
-            },
-            _ => {
-                (StatusCode::INTERNAL_SERVER_ERROR, String::from("something bad happened"))
-            }
-        }.into_response()
+            Error::DistributionSpecError(dec) => (dec.status_code(), format!("{:?}", dec)),
+            Error::InvalidUuid(_) => (StatusCode::BAD_REQUEST, format!("{}", self)),
+            Error::InvalidDigest(_) => (StatusCode::BAD_REQUEST, format!("{}", self)),
+            Error::MissingHeader(_) => (StatusCode::BAD_REQUEST, format!("{}", self)),
+            Error::InvalidHeaderValue(_) => (StatusCode::BAD_REQUEST, format!("{}", self)),
+            Error::MissingPathParameter(_) => (StatusCode::BAD_REQUEST, format!("{}", self)),
+            _ => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                String::from("something bad happened"),
+            ),
+        }
+        .into_response()
     }
 }

--- a/src/http/blobs.rs
+++ b/src/http/blobs.rs
@@ -104,6 +104,7 @@ async fn uploads_put(
     Path(path_params): Path<HashMap<String, String>>,
     TypedHeader(content_length): TypedHeader<ContentLength>,
     TypedHeader(content_type): TypedHeader<ContentType>,
+    option_content_range: Option<TypedHeader<ContentRange>>,
     Query(query_params): Query<HashMap<String, String>>,
     request: Request<Body>,
     Extension(metadata): Extension<Arc<PostgresMetadata>>,
@@ -112,36 +113,61 @@ async fn uploads_put(
     let repo_name = path_params
         .get("repository")
         .ok_or_else(|| Error::MissingPathParameter("repository"))?;
-    let digest: &String = match query_params.get("digest") {
-        None => return upload_session_id(repo_name, metadata).await,
-        Some(dgst) => dgst,
-    };
-    let session_uuid = match path_params.get("session_uuid") {
-        None => return Err(Error::MissingPathParameter("session_uuid")),
-        Some(uuid_str) => Uuid::parse_str(uuid_str)?,
-    };
+    let digest: &String = query_params
+        .get("digest")
+        .ok_or_else(|| Error::MissingQueryParameter("digest"))?;
+    let session_uuid = path_params
+        .get("session_uuid")
+        .map(|s| Uuid::parse_str(s))
+        .transpose()?
+        .ok_or_else(|| Error::MissingPathParameter("session_uuid"))?;
 
-    // verify the session uuid in the url exists, otherwise reject the put
-    match metadata.get_session(session_uuid).await {
-        Ok(_) => (),
-        // TODO: may need to distinguish later between database connection errors and session not
-        // found errors
-        Err(_) => {
-            return Err(Error::DistributionSpecError(
-                DistributionErrorCode::BlobUploadUnknown,
-            ))
+    // retrieve the session or fail if it doesn't exist
+    let session = metadata
+        .get_session(session_uuid)
+        .await
+        .map_err(|_| Error::DistributionSpecError(DistributionErrorCode::BlobUploadUnknown))?;
+
+    // determine if this is a monolithic POST-PUT or the final request in a chunked POST-PATCH-PUT
+    // sequence
+    let response = match session.chunk_info {
+        // POST-PATCH-PUT
+        Some(mut chunk_info) => {
+            let TypedHeader(content_range) =
+                option_content_range.ok_or_else(|| Error::MissingHeader("ContentRange"))?;
+            upload_chunk(
+                &mut chunk_info,
+                content_length,
+                content_range,
+                request,
+                objects.clone(),
+            )
+            .await?;
+
+            objects.finalize_chunked_upload(&session.uuid, &chunk_info).await?;
+            metadata.insert_blob(digest, &session.uuid).await?;
+
+            let location = format!("/v2/{}/blobs/{}", repo_name, session.uuid);
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                HeaderName::from_static("Location"),
+                HeaderValue::from_str(&location).unwrap(),
+            );
+            (StatusCode::CREATED, headers, "").into_response()
+        }
+        // POST-PUT
+        None => {
+            upload_blob(
+                repo_name,
+                digest,
+                content_length,
+                request,
+                metadata.clone(),
+                objects,
+            )
+            .await?
         }
     };
-
-    let response = upload_blob(
-        repo_name,
-        digest,
-        content_length,
-        request,
-        metadata.clone(),
-        objects,
-    )
-    .await?;
 
     match metadata.delete_session(session_uuid).await {
         Ok(_) => (),
@@ -166,24 +192,17 @@ async fn uploads_patch(
     let repo_name = path_params
         .get("repository")
         .ok_or_else(|| Error::MissingPathParameter("repository"))?;
-    let session_uuid = match path_params.get("session_uuid") {
-        None => return Err(Error::MissingPathParameter("session_uuid")),
-        Some(uuid_str) => Uuid::parse_str(uuid_str)?,
-    };
+    let session_uuid = path_params
+        .get("session_uuid")
+        .map(|s| Uuid::parse_str(s))
+        .transpose()?
+        .ok_or_else(|| Error::MissingPathParameter("session_uuid"))?;
 
-    // retrieve the session from metadata backend
-    let mut session = match metadata.get_session(session_uuid).await {
-        Ok(session) => session,
-        // TODO: may need to distinguish later between database connection errors and session not
-        // found errors
-        Err(_) => {
-            return Err(Error::DistributionSpecError(
-                DistributionErrorCode::BlobUploadUnknown,
-            ))
-        }
-    };
-
-    let mut range_end: u64 = 0;
+    // retrieve the session or fail if it doesn't exist
+    let mut session = metadata
+        .get_session(session_uuid)
+        .await
+        .map_err(|_| Error::DistributionSpecError(DistributionErrorCode::BlobUploadUnknown))?;
 
     let mut chunk_info = match session.chunk_info {
         Some(Json(info)) => info,
@@ -195,22 +214,15 @@ async fn uploads_patch(
         }
     };
 
-    // verify the request's ContentRange against the last chunk's end of range
-    if let Some(range) = content_range.bytes_range() {
-        if range.0 != chunk_info.last_range_end {
-            return Err(Error::DistributionSpecError(
-                DistributionErrorCode::BlobUploadInvalid,
-            ));
-        }
-        range_end = range.1;
-    }
+    upload_chunk(
+        &mut chunk_info,
+        content_length,
+        content_range,
+        request,
+        objects.clone(),
+    )
+    .await?;
 
-    objects
-        .clone()
-        .upload_chunk(&mut chunk_info, request.into_body())
-        .await?;
-
-    chunk_info.last_range_end = range_end;
     session.chunk_info = Some(Json(chunk_info));
 
     // TODO: validate content length of chunk
@@ -238,11 +250,12 @@ async fn upload_blob(
     let oci_digest: OciDigest = digest.try_into()?;
 
     // upload blob
+    let uuid = Uuid::new_v4();
     let digester = oci_digest.digester();
     let body = StreamObjectBody::from_body(request.into_body(), digester);
     objects
         .clone()
-        .upload_blob(digest, body.into())
+        .upload_blob(&uuid, body.into())
         .await
         .unwrap();
 
@@ -250,7 +263,7 @@ async fn upload_blob(
     // TODO: validate content length
 
     // insert metadata
-    metadata.clone().insert_blob(digest).await.unwrap();
+    metadata.clone().insert_blob(digest, &uuid).await?;
 
     let location = format!("/v2/{}/blobs/{}", repo_name, digest,);
     let mut headers = HeaderMap::new();
@@ -259,6 +272,37 @@ async fn upload_blob(
         HeaderValue::from_str(&location).unwrap(),
     );
     Ok((StatusCode::CREATED, headers, "").into_response())
+}
+
+async fn upload_chunk(
+    chunk_info: &mut ChunkInfo,
+    content_length: ContentLength,
+    content_range: ContentRange,
+    request: Request<Body>,
+    objects: Arc<S3>,
+) -> Result<()> {
+    let mut range_end: u64 = 0;
+    // verify the request's ContentRange against the last chunk's end of range
+    if let Some(range) = content_range.bytes_range() {
+        if range.0 != chunk_info.last_range_end {
+            return Err(Error::DistributionSpecError(
+                DistributionErrorCode::BlobUploadInvalid,
+            ));
+        }
+        range_end = range.1;
+    }
+
+    objects
+        .clone()
+        .upload_chunk(chunk_info, request.into_body())
+        .await?;
+
+    chunk_info.last_range_end = range_end;
+
+    // TODO: validate content length of chunk
+    // TODO: update incremental digest state on session
+
+    Ok(())
 }
 
 async fn upload_session_id(repo_name: &str, metadata: Arc<PostgresMetadata>) -> Result<Response> {

--- a/src/metadata/postgres.rs
+++ b/src/metadata/postgres.rs
@@ -28,15 +28,16 @@ pub struct PostgresMetadata {
 }
 
 impl PostgresMetadata {
-    pub async fn insert_blob(&self, digest: &str) -> Result<i64> {
+    pub async fn insert_blob(&self, digest: &str, object_key: &Uuid) -> Result<i64> {
         let mut conn = self.pool.acquire().await?;
         let record = sqlx::query!(
             r#"
-INSERT INTO blobs ( digest )
-VALUES ( $1 )
+INSERT INTO blobs ( digest, object_key )
+VALUES ( $1, $2 )
 RETURNING id
             "#,
             digest,
+            object_key,
         )
         .fetch_one(&mut conn)
         .await?;

--- a/src/objects/s3.rs
+++ b/src/objects/s3.rs
@@ -57,11 +57,11 @@ pub struct S3 {
 }
 
 impl S3 {
-    pub async fn upload_blob(&self, digest: &str, body: Body) -> Result<()> {
+    pub async fn upload_blob(&self, uuid: &Uuid, body: Body) -> Result<()> {
         let _put_object_output = self
             .client
             .put_object()
-            .key(digest)
+            .key(uuid.to_string())
             .body(body.into())
             .bucket(&self.bucket_name)
             .send()
@@ -105,11 +105,12 @@ impl S3 {
         Ok(())
     }
 
-    pub async fn finalize_chunked_upload(&self, digest: &str) -> Result<()> {
+    pub async fn finalize_chunked_upload(&self, uuid: &Uuid, chunk: &ChunkInfo) -> Result<()> {
         let _complete_multipart_upload_output = self
             .client
             .complete_multipart_upload()
-            .key(digest)
+            .upload_id(chunk.upload_id.clone())
+            .key(uuid.to_string())
             .bucket(&self.bucket_name)
             .send()
             .await?;


### PR DESCRIPTION
* handle the case for `PUT /v2/<repo>/blobs/uploads/<session>?digest=<digest>` in POST-PATCH-PUT where we need to finalize the multi part upload and put the digest in the metadata DB.
* factor out a `upload_chunk` to be shared between `PUT` and `PATCH`.
* update the `blobs` data model to include a `UUID` type field
* reference blobs in the object store by `UUID` rather than digest.
  * this elmininates the need for moving and deleting bucket keys at the end of POST-PUT and POST-PATCH-PUT sequences which is necessary when using digests as keys because the digest in those sequences is only known at the final PUT step
